### PR TITLE
feat(testing): support runner and dev server args

### DIFF
--- a/packages/testing/index.js
+++ b/packages/testing/index.js
@@ -35,6 +35,7 @@ module.exports = function(api, ctx) {
     const args = yargs
       .array('unit')
       .array('e2e')
+      .string('dev')
       .parse(rawArgs)
     if (!args.unit && !args.e2e) {
       console.log(
@@ -48,7 +49,7 @@ module.exports = function(api, ctx) {
     args.e2e = args.e2e || []
 
     args.unit.forEach(runner => {
-      if (!testingConfig[`unit-${runner}`]) {
+      if (!testingConfig[`unit-${runner.split(' ')[0]}`]) {
         // TODO: install instructions for non-scoped extension
         console.error(
           chalk`You tried to run tests with {bold ${runner}}, but it is not installed. Please install @quasar/quasar-app-extension-unit-${runner} with {bold quasar ext --add @quasar/unit-${runner}}`
@@ -58,7 +59,7 @@ module.exports = function(api, ctx) {
     })
 
     args.e2e.forEach(runner => {
-      if (!testingConfig[`e2e-${runner}`]) {
+      if (!testingConfig[`e2e-${runner.split(' ')[0]}`]) {
         // TODO: install instructions for non-scoped extension
         console.error(
           chalk`You tried to run tests with {bold ${runner}}, but it is not installed. Please install @quasar/quasar-app-extension-e2e-${runner} with {bold quasar ext --add @quasar/e2e-${runner}}`
@@ -68,10 +69,11 @@ module.exports = function(api, ctx) {
     })
 
     // If --dev was passed or e2e tests are being run
-    if (args.dev || args.e2e.length > 0) {
+    if (args.dev != null || args.e2e.length > 0) {
       // Start dev server
       // TODO: use interactive output
-      const devServer = execa('quasar', ['dev'], {
+      const devServerArgs = (args.dev || '').split(' ')
+      const devServer = execa('quasar', ['dev', ...devServerArgs], {
         cwd: api.resolve.app('.'),
         env: { FORCE_COLOR: true }
       })
@@ -130,8 +132,12 @@ module.exports = function(api, ctx) {
 
     async function startTests(serverUrl, callback) {
       let failedRunners = []
-      const runTest = (runner, type) =>
+      const runTest = (userCommand, type) =>
         new Promise(resolve => {
+          // Split runner command into command and arguments
+          const runner = userCommand.split(' ')[0]
+          const userArgs = userCommand.split(' ').slice(1)
+
           console.log(
             chalk`
               {bold \n{bgBlue  RUN: } Running ${type} tests with ${runner}\n}
@@ -145,7 +151,10 @@ module.exports = function(api, ctx) {
             .split(' ')
           // Remove first arg, that is the command
           const runnerCommand = runnerCommandArgs.shift()
-          const testRunner = execa(runnerCommand, runnerCommandArgs, {
+          // Mix user args and runner args
+          const finalArgs = [...runnerCommandArgs, ...userArgs]
+          console.log('$', runner, finalArgs.join(' '))
+          const testRunner = execa(runnerCommand, finalArgs, {
             stdio: 'inherit'
           })
           testRunner.on('exit', code => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [ ] Documentation
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

in the form of:
`quasar run @quasar/testing test -- --unit "jest --runInBand" "ava --serial" --e2e cypress --dev="--mode ssr"`

`--dev="--x"` is required, `--dev "--x"` will not work.

Also logs executed test runner command.