### PR TITLE
[URGENT] fix(testing): execa not gettting imported

### DIFF
--- a/packages/testing/install.js
+++ b/packages/testing/install.js
@@ -6,6 +6,8 @@
  */
 
 module.exports = async function(api) {
+  const execa = require('execa')
+
   api.render('./base', {}, true)
 
   for (const harness of api.prompts.harnesses) {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

**Other information:**
