### PR TITLE
Fix(jest): demo test not obeying eslint, fixes #39

### DIFF
--- a/packages/unit-jest/base/test/jest/.eslintrc.js
+++ b/packages/unit-jest/base/test/jest/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    jest: true
+  }
+}

--- a/testing-test/test/jest/__tests__/App.spec.js
+++ b/testing-test/test/jest/__tests__/App.spec.js
@@ -1,15 +1,14 @@
-/* eslint-disable */
 /**
  * @jest-environment jsdom
  */
 
-import { mount, createLocalVue, shallowMount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 import { mountQuasar } from '~/test/jest/utils'
-import QBUTTON from './demo/QBtn-demo.vue'
-import Quasar, { Qbtn } from 'quasar'
+import QButton from './demo/QBtn-demo.vue'
+import Quasar from 'quasar'
 
 describe('Mount Quasar', () => {
-  const wrapper = mountQuasar(QBUTTON, {
+  const wrapper = mountQuasar(QButton, {
     utils: {
       appError: () => (fn) => fn,
       appSuccess: () => (fn) => fn
@@ -33,14 +32,14 @@ describe('Mount Quasar', () => {
 
   it('sets the correct default data', () => {
     expect(typeof vm.counter).toBe('number')
-    const defaultData2 = QBUTTON.data()
+    const defaultData2 = QButton.data()
     expect(defaultData2.counter).toBe(0)
   })
 
   it('correctly updates data when button is pressed', () => {
     const localVue = createLocalVue()
     localVue.use(Quasar, { components: ['QBtn']})
-    const wrapper2 = mount(QBUTTON, {
+    const wrapper2 = mount(QButton, {
       localVue
     })
     const vm2 = wrapper2.vm


### PR DESCRIPTION
The base template now includes a `.eslintrc.js` file that sets `env: { jest: true}}`. It also removes unused imports in the demo test to pass a linting run.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
