### PR TITLE
fix with localVue.use(Quasar)

### DIFF
--- a/packages/unit-ava/src/base/test/ava/utils/index.js
+++ b/packages/unit-ava/src/base/test/ava/utils/index.js
@@ -16,17 +16,17 @@ const mockSsrContext = () => {
   }
 }
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
-localVue.use(VueRouter)
-localVue.use(Quasar)
-
 // https://eddyerburgh.me/mock-vuex-in-vue-unit-tests
 export const mountQuasar = (component, options = {}) => {
+  const localVue = createLocalVue()
   const app = {}
   const store = new Vuex.Store({})
   const router = new VueRouter()
-
+  
+  localVue.use(Vuex)
+  localVue.use(VueRouter)
+  localVue.use(Quasar)
+  
   if (options) {
     const ssrContext = options.ssr ? mockSsrContext() : null
 

--- a/packages/unit-jest/src/base/test/jest/utils/index.js
+++ b/packages/unit-jest/src/base/test/jest/utils/index.js
@@ -16,17 +16,17 @@ const mockSsrContext = () => {
   }
 }
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
-localVue.use(VueRouter)
-localVue.use(Quasar)
-
 // https://eddyerburgh.me/mock-vuex-in-vue-unit-tests
 export const mountQuasar = (component, options = {}) => {
+  const localVue = createLocalVue()
   const app= {}
   const store = new Vuex.Store({})
   const router = new VueRouter()
-
+  
+  localVue.use(Vuex)
+  localVue.use(VueRouter)
+  localVue.use(Quasar)
+  
   if (options) {
     const ssrContext = options.ssr ? mockSsrContext() : null
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

I've tried `quasar run @quasar/testing test -- --unit jest --dev` on a fresh Quasar install + testing extension installed with unit-jest harness

I got the following result (Windows 10, PowerShell):
```
 RUN:  Running unit tests with jest

$ jest
 FAIL  test/jest/__tests__/App.spec.js
  Mount Quasar
    √ passes the sanity check and creates a wrapper (5ms)
    √ has a created hook
    √ accesses the shallowMount (3ms)
    √ sets the correct default data (1ms)
    × correctly updates data when button is pressed (6ms)

  ● Mount Quasar › correctly updates data when button is pressed

    [vue-test-utils]: find did not return button, cannot call trigger() on empty Wrapper

console.error node_modules/vue/dist/vue.common.dev.js:630
    [Vue warn]: Error in render: "TypeError: Cannot read property 'lang' of undefined"

console.error node_modules/vue/dist/vue.common.dev.js:1893
    TypeError: Cannot read property 'lang' of undefined

console.error node_modules/vue/dist/vue.common.dev.js:630
    [Vue warn]: Unknown custom element: <q-btn> - did you register the component correctly? For recursive components, make sure to provide the "name" option.`
```
Turned out that the 3 last errors kept appearing even if test suite was empty. Tracking down the stack trace of the second error, when changing the scope of `localVue.use(Quasar)`, error messages disappeared (Quasar properties not fully instantiated when loading jest/utils/index.js?).

I propose that "patch" for unit-ava harness too (feel free to reject the corresponding file) ; I would have been happy to test but on a fresh install (`quasar ext add @quasar/testing-unit-ava`), when running  `quasar run @quasar/testing test -- --unit ava --dev` I get:
```
RUN:  Running unit tests with ava

$ ava

  × No tests found in test\ava\__tests__\App.spec.js

  1 uncaught exception

  Uncaught exception in test\ava\__tests__\App.spec.js

  C:\Users\...\test-project\node_modules\vue\dist\vue.runtime.common.dev.js:4239

  ReferenceError: performance is not defined
```