### PR TITLE
Set default config to `noStackTrace: false`

### DIFF
--- a/packages/unit-jest/src/base/jest.config.js
+++ b/packages/unit-jest/src/base/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   setupFilesAfterEnv: [
     '<rootDir>/test/jest/jest.setup.js'
   ],
-  noStackTrace: true,
+  noStackTrace: false,
   bail: true,
   cache: false,
   verbose: true,


### PR DESCRIPTION
change default config for JEST:  `noStackTrace: false` 
In my opinion it is muuuch easier to work with the tests to see where they are failing when they fail.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

change default config for JEST

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Other information:**