### PR TITLE
[WIP] feat(unit-ava): use quasar.common.js

### DIFF
--- a/packages/unit-ava/src/babelrc/babel.config.js
+++ b/packages/unit-ava/src/babelrc/babel.config.js
@@ -17,7 +17,7 @@ if (process.env.QUASAR_APP_TEST) {
     {
       root: ['./'],
       alias: {
-        quasar: './node_modules/quasar/dist/quasar.umd.js',
+        quasar: './node_modules/quasar/dist/quasar.common.js',
         'test-utils': '@vue/test-utils',
         '~': './'
       }

--- a/packages/unit-ava/src/base/test/ava/___tests__/App.spec.js
+++ b/packages/unit-ava/src/base/test/ava/___tests__/App.spec.js
@@ -1,10 +1,19 @@
 import { mount, createLocalVue } from '@vue/test-utils'
 import QButton from './demo/QBtn-demo.vue'
-import Quasar, { QBtn } from 'quasar'
+import * as All from 'quasar'
 import test from 'ava'
+const { Quasar, date } = All
+
+const components = Object.keys(All).reduce((object, key) => {
+  const val = All[key]
+  if (val && val.component && val.component.name != null) {
+    object[key] = val
+  }
+  return object
+}, {})
 
 const localVue = createLocalVue()
-localVue.use(Quasar, { components: { QBtn } })
+localVue.use(Quasar, { components })
 const wrapper = mount(QButton, {
   localVue
 })
@@ -31,13 +40,7 @@ test('sets the correct default data', t => {
 })
 
 test('correctly updates data when button is pressed', t => {
-  const localVue = createLocalVue()
-  localVue.use(Quasar, { components: ['QBtn'] })
-  const wrapper2 = mount(QButton, {
-    localVue
-  })
-  const vm2 = wrapper2.vm
-  const button = wrapper2.find('button')
+  const button = wrapper.find('button')
   button.trigger('click')
-  t.is(vm2.counter, 1)
+  t.is(vm.counter, 1)
 })

--- a/packages/unit-ava/src/wallabyjs/wallaby.js
+++ b/packages/unit-ava/src/wallabyjs/wallaby.js
@@ -12,7 +12,7 @@ module.exports = wallaby => {
           alias: {
             quasar: path.join(
               wallaby.projectCacheDir,
-              'node_modules/quasar/dist/quasar.umd.js'
+              'node_modules/quasar/dist/quasar.common.js'
             ),
             'test-utils': path.join(
               wallaby.projectCacheDir,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Feature

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Uses `qusar.common.js` instead of `quasar.umd.js`. Imports all components. Wallaby will work on initial run, but updated runs after changing a file will fail.