### PR TITLE
Fix, put the missing err parameter in the callback handler

### DIFF
--- a/packages/e2e-cypress/src/base/test/cypress/support/index.js
+++ b/packages/e2e-cypress/src/base/test/cypress/support/index.js
@@ -18,7 +18,7 @@ import './commands'
 
 const resizeObserverLoopErrRe = /^ResizeObserver loop limit exceeded/
 
-Cypress.on('uncaught:exception', () => {
+Cypress.on('uncaught:exception', (err) => {
   if (resizeObserverLoopErrRe.test(err.message)) {
     // returning false here prevents Cypress from
     // failing the test


### PR DESCRIPTION
I encountered error `err is not defined` and I found this is the fix for it