### PR TITLE
#118 fix proposal for 'quasar test' command returns exit code 0 despi…

### DIFF
--- a/packages/testing/src/index.js
+++ b/packages/testing/src/index.js
@@ -99,8 +99,8 @@ module.exports = async function(api) {
       }
 
       // Kill dev server on exit
-      process.on('SIGINT', killDevServer)
-      process.on('SIGTERM', killDevServer)
+      process.on('SIGINT', beforeExit)
+      process.on('SIGTERM', beforeExit)
 
       // Handle Ctrl+C on Windows
       if (process.platform === 'win32') {

--- a/packages/testing/src/index.js
+++ b/packages/testing/src/index.js
@@ -91,12 +91,11 @@ module.exports = async function(api) {
         if (!e.killed) throw new Error(e)
       })
 
-      const killDevServer = hasFailed => {
-        if (!devServer) {
-          process.exit(hasFailed ? 1 : 0)
+      const beforeExit = hasFailed => {
+        if (devServer) {
+          devServer.kill()
         }
-
-        devServer.kill()
+        process.exit(hasFailed ? 1 : 0)
       }
 
       // Kill dev server on exit
@@ -131,14 +130,18 @@ module.exports = async function(api) {
             await startTests(
               // The dev server url
               data.match(doneRegex)[1],
-              killDevServer
+              beforeExit
             )
           }
         }
       })
     } else {
       // Just run tests without dev server
-      await startTests()
+      await startTests(
+        // ignore the dev server url
+        undefined,
+        beforeExit
+      )
     }
 
     async function startTests(serverUrl, callback) {


### PR DESCRIPTION
…te failed tests

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
