### PR TITLE
chore(cypress): remove [js] workaround

### DIFF
--- a/packages/e2e-cypress/src/no-typescript/test/cypress/plugins/index.js
+++ b/packages/e2e-cypress/src/no-typescript/test/cypress/plugins/index.js
@@ -14,18 +14,8 @@
 
 // cypress/plugins/index.js
 
-module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-  // console.log(config); // see what all is in here!
-
-
-  // Chrome:: Hack for shaking AUT. Cypress Issue: https://github.com/cypress-io/cypress/issues/1620
-  on('before:browser:launch', (browser = {}, args) => {
-    if (browser.name === 'chrome') {
-      args.push('--disable-blink-features=RootLayerScrolling');
-      return args;
-    }
-    return true;
-  });
+const pluginConfig = (/*on, config*/) => {
+  //
 };
+
+export default pluginConfig;


### PR DESCRIPTION
Copied this js [non-typescript] version directly from the latest [ts version](https://github.com/quasarframework/quasar-testing/blob/dev/packages/e2e-cypress/src/typescript/test/cypress/plugins/index.ts)

This was resolved in Cypress v3.0.3 and only applies to Chrome < 68
The workaround is no longer needed.

This would supersede #107 as the file modified in that PR no longer exists
and this matches the current `@quasar/testing-e2e-cypress` ts default.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
