### PR TITLE
fix: #106 SFC test loader matcher

### DIFF
--- a/packages/unit-jest/src/loader/test/loaders/jest-loader.js
+++ b/packages/unit-jest/src/loader/test/loaders/jest-loader.js
@@ -7,7 +7,7 @@ module.exports = function (source) {
 
   const filename = path.parse(this.resourcePath).name
 
-  const extension = (options && options.extension) || '_jest.spec.js'
+  const extension = (options && options.extension) || '.jest.spec.js'
   const dir = `${this.context}/__tests__`
   console.log(`Created test file: ${filename}`)
   if (!fs.existsSync(dir)){


### PR DESCRIPTION
jest.config.js matches test files on .jest.spec.js
jest-loader.js is exporting SFC tests with _jest.spec.js

This fix syncs the export+match so exported tests can be found by Jest

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
