### PR TITLE
fix: Exit non-zero on test fail | Fix: #118,#124

### DIFF
--- a/packages/testing/src/index.js
+++ b/packages/testing/src/index.js
@@ -215,7 +215,7 @@ module.exports = async function(api) {
         await runTest(runner, 'security')
       }
       failedRunners.forEach(runner => {
-        if (!args.security) {
+        if (args.security.length === 0) {
           console.error(
             chalk`{bgRed FAILED TESTS: } Tests with ${runner} did not pass.`
           )

--- a/packages/testing/src/index.js
+++ b/packages/testing/src/index.js
@@ -224,6 +224,10 @@ module.exports = async function(api) {
       if (callback) {
         // Exit with code 1 if some tests failed
         callback(failedRunners.length > 0)
+      } else {
+        if (failedRunners.length > 0) {
+          process.exit(1)
+        }
       }
     }
   })


### PR DESCRIPTION
When running `quasar test --unit jest` and a test fails it is expected that Quasar fails with a non-zero exit code.
Pre-push hook and CI/CD pipelines may use the exit code to determine success/fail and automatically react accordingly.

PR #127 was originally proposed to resolve this issue, but I had errors when testing it
and I could not determine how to reliably resolve that implementation.

This proposal is a simplified alternative and more directly scoped to the core issue.

Closes: #118 
Closes: #124 

Supersedes: PR #127 

---

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
