### PR TITLE
chore(TODO): cypress typescript fix has been released

### DIFF
--- a/packages/e2e-cypress/src/typescript/test/cypress/support/commands.ts
+++ b/packages/e2e-cypress/src/typescript/test/cypress/support/commands.ts
@@ -54,9 +54,7 @@ declare namespace Cypress {
 }
 
 // Find elements by "data-cy" attribute, making your tests
-//  more robust with respect to codebase changes
-// TODO: remove when https://github.com/cypress-io/cypress/issues/7510 is released
-// eslint-disable-next-line @typescript-eslint/no-misused-promises
+// more robust with respect to codebase changes
 Cypress.Commands.add('dataCy', (value: string) => {
   return cy.get(`[data-cy=${value}]`);
 });


### PR DESCRIPTION
https://github.com/cypress-io/cypress/issues/7510 seems to have been released, so the TODO can be removed now

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
