### PR TITLE
fix: cypress npm scripts for windows

### DIFF
--- a/packages/e2e-cypress/src/install.js
+++ b/packages/e2e-cypress/src/install.js
@@ -68,8 +68,8 @@ module.exports = function (api) {
           // "http-get" must be used because "webpack-dev-server" won't answer
           //  HEAD requests which are performed by default by the underlying "wait-on"
           // See https://github.com/bahmutov/start-server-and-test#note-for-webpack-dev-server-users 
-          "test:e2e": "cross-env E2E_TEST=true start-test 'quasar dev' http-get://localhost:8080 'cypress open'",
-          "test:e2e:ci": "cross-env E2E_TEST=true start-test 'quasar dev' http-get://localhost:8080 'cypress run'"
+          "test:e2e": "cross-env E2E_TEST=true start-test \"quasar dev\" http-get://localhost:8080 \"cypress open\"",
+          "test:e2e:ci": "cross-env E2E_TEST=true start-test \"quasar dev\" http-get://localhost:8080 \"cypress run\""
         }
       }
       return extendPackageJson = __mergeDeep(extendPackageJson, scripts)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on Windows
- [ ] It's been tested on Linux
- [x] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The npm scripts will not work on windows because of the single quotes.
This is already implemented in the `"concurrently:dev:jest"` npm script:
https://github.com/quasarframework/quasar-testing/blob/e2256cc78e15665fb362954ea7b579ca4297a46b/packages/unit-jest/src/install.js#L85