### PR TITLE
docs: Adding Testing Harnesses Manager to Q1

### DIFF
--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,6 +2,9 @@
 
 ```shell
 $ quasar ext add @quasar/testing
+
+# For Quasar v1.x.x use version 1
+$ quasar ext add @quasar/testing@1
 ```
 
 This AE is meant to centralize the management of all testing harnesses.


### PR DESCRIPTION
The README.md file was missing a description for adding Testing harness to Quasar 1.x.x, so, for the sake of of still using it, I've added it.