### PR TITLE
fix: QDialog is not mounted in tests when used with mount() (fix #72)

### DIFF
--- a/packages/unit-jest/README.md
+++ b/packages/unit-jest/README.md
@@ -109,11 +109,18 @@ We don't plan to migrate it, unless many people ask for it and someone from the 
 
 #### Testing portal-based components
 
-Portal-based component (eg. QMenu, QDialog, etc) require a `body` tag where to attach themselves which unluckily `vue-jest` doesn't provide.
-While we search for a way to workaround this (if possible), the recommended way of testing these components with Jest is to abstract them into their own component and test them in isolation.
+Portal-based component (eg. QMenu, QDialog, etc) require a `body` so that they can attach themselves to the document.
 
-Note that, if you end up trying to test interactions between multiple components, you are probably trying to test an e2e/integration scenario using a unit testing tool.
-Take a look to our Cypress AE instead: it supports proper Component Testing since version `4.0.0-beta.7` and may be what you're searching for.
+Vue Test Utils provides a DOMWrapper that allows you to mount the document body, and access the document for testing
+purposes. The example provided in `MyDialog.spec.js` demonstrates how this can be implemented.
+
+However, if this does not work for your specific use case, the recommended way of testing these components with Jest is
+to abstract them into their own component and test them in isolation.
+
+Note that, if you end up trying to test interactions between multiple components, you are probably trying to test an
+e2e/integration scenario using a unit testing tool.
+Take a look to our Cypress AE instead: it supports proper Component Testing since version `4.0.0-beta.7` and may be what
+you're searching for.
 
 #### Mock i18n
 

--- a/packages/unit-jest/src/templates/no-typescript/test/jest/___tests__/MyDialog.spec.js
+++ b/packages/unit-jest/src/templates/no-typescript/test/jest/___tests__/MyDialog.spec.js
@@ -1,18 +1,31 @@
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
-import { describe, expect, it } from '@jest/globals';
-import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { DOMWrapper, mount } from '@vue/test-utils';
 import MyDialog from './demo/MyDialog';
 
 installQuasarPlugin();
 
+document.body.innerHTML = `
+  <div>
+    <div id="app"></div>
+  </div>
+`;
+
 describe('MyDialog', () => {
-  it('should mount MyDialog', () => {
-    const wrapper = mount(MyDialog, {
+  beforeEach(() => {
+    mount(MyDialog, {
+      attachTo: document.getElementById('app'),
       data: () => ({
         isDialogOpen: true,
       }),
     });
+  });
 
-    expect(wrapper.exists()).toBe(true);
+  it('should attach the dialog to the document body and allow for testing', () => {
+    const documentWrapper = new DOMWrapper(document.body);
+    const dialog = documentWrapper.find('.q-dialog');
+
+    expect(dialog.exists()).toBeTruthy();
+    expect(dialog.html()).toContain('Custom dialog which should be tested');
   });
 });

--- a/packages/unit-jest/src/templates/no-typescript/test/jest/___tests__/MyDialog.spec.js
+++ b/packages/unit-jest/src/templates/no-typescript/test/jest/___tests__/MyDialog.spec.js
@@ -5,27 +5,26 @@ import MyDialog from './demo/MyDialog';
 
 installQuasarPlugin();
 
-document.body.innerHTML = `
-  <div>
-    <div id="app"></div>
-  </div>
-`;
-
 describe('MyDialog', () => {
   beforeEach(() => {
     mount(MyDialog, {
-      attachTo: document.getElementById('app'),
       data: () => ({
         isDialogOpen: true,
       }),
     });
   });
 
-  it('should attach the dialog to the document body and allow for testing', () => {
-    const documentWrapper = new DOMWrapper(document.body);
-    const dialog = documentWrapper.find('.q-dialog');
+  it('should mount the document body and expose for testing', () => {
+    const wrapper = new DOMWrapper(document.body);
 
-    expect(dialog.exists()).toBeTruthy();
-    expect(dialog.html()).toContain('Custom dialog which should be tested');
+    expect(wrapper.find('.q-dialog').exists()).toBeTruthy();
+  });
+
+  it('can check the inner text of the dialog', () => {
+    const wrapper = new DOMWrapper(document.body);
+
+    expect(wrapper.find('.q-dialog').html()).toContain(
+      'Custom dialog which should be tested',
+    );
   });
 });

--- a/packages/unit-jest/src/templates/typescript/test/jest/___tests__/MyDialog.spec.js
+++ b/packages/unit-jest/src/templates/typescript/test/jest/___tests__/MyDialog.spec.js
@@ -1,18 +1,31 @@
 import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-jest';
-import { describe, expect, it } from '@jest/globals';
-import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { DOMWrapper, mount } from '@vue/test-utils';
 import MyDialog from './demo/MyDialog';
 
 installQuasarPlugin();
 
+document.body.innerHTML = `
+  <div>
+    <div id="app"></div>
+  </div>
+`;
+
 describe('MyDialog', () => {
-  it('should mount MyDialog', () => {
-    const wrapper = mount(MyDialog, {
+  beforeEach(() => {
+    mount(MyDialog, {
+      attachTo: document.getElementById('app'),
       data: () => ({
         isDialogOpen: true,
       }),
     });
+  });
 
-    expect(wrapper.exists()).toBe(true);
+  it('should attach the dialog to the document body and allow for testing', () => {
+    const documentWrapper = new DOMWrapper(document.body);
+    const dialog = documentWrapper.find('.q-dialog');
+
+    expect(dialog.exists()).toBeTruthy();
+    expect(dialog.html()).toContain('Custom dialog which should be tested');
   });
 });

--- a/packages/unit-jest/src/templates/typescript/test/jest/___tests__/MyDialog.spec.js
+++ b/packages/unit-jest/src/templates/typescript/test/jest/___tests__/MyDialog.spec.js
@@ -5,27 +5,26 @@ import MyDialog from './demo/MyDialog';
 
 installQuasarPlugin();
 
-document.body.innerHTML = `
-  <div>
-    <div id="app"></div>
-  </div>
-`;
-
 describe('MyDialog', () => {
   beforeEach(() => {
     mount(MyDialog, {
-      attachTo: document.getElementById('app'),
       data: () => ({
         isDialogOpen: true,
       }),
     });
   });
 
-  it('should attach the dialog to the document body and allow for testing', () => {
-    const documentWrapper = new DOMWrapper(document.body);
-    const dialog = documentWrapper.find('.q-dialog');
+  it('should mount the document body and expose for testing', () => {
+    const wrapper = new DOMWrapper(document.body);
 
-    expect(dialog.exists()).toBeTruthy();
-    expect(dialog.html()).toContain('Custom dialog which should be tested');
+    expect(wrapper.find('.q-dialog').exists()).toBeTruthy();
+  });
+
+  it('can check the inner text of the dialog', () => {
+    const wrapper = new DOMWrapper(document.body);
+
+    expect(wrapper.find('.q-dialog').html()).toContain(
+      'Custom dialog which should be tested',
+    );
   });
 });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar-test/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [x] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on Windows
- [x] It's been tested on Linux
- [x] It's been tested on MacOS
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
