### PR TITLE
fix: #223 - A package-manager-agnostic way to check the installed bundler

### DIFF
--- a/packages/e2e-cypress/src/helpers/cct-dev-server/index.ts
+++ b/packages/e2e-cypress/src/helpers/cct-dev-server/index.ts
@@ -1,11 +1,7 @@
 /* eslint-disable */
 /// <reference types="cypress" />
-import { promisify } from 'util';
-import { exec as originalExec } from 'child_process';
 
 type AvailableBundlers = 'vite' | 'webpack';
-
-const exec = promisify(originalExec);
 
 async function exportQuasarConfig(bundler: AvailableBundlers): Promise<any> {
   let quasarAppPackage = `@quasar/app-${bundler}`;

--- a/packages/e2e-cypress/src/helpers/cct-dev-server/index.ts
+++ b/packages/e2e-cypress/src/helpers/cct-dev-server/index.ts
@@ -11,10 +11,9 @@ async function exportQuasarConfig(bundler: AvailableBundlers): Promise<any> {
   let quasarAppPackage = `@quasar/app-${bundler}`;
 
   if (bundler === 'webpack') {
-    try {
-      await exec('npm ls @quasar/app-webpack');
-    } catch (e) {
-      quasarAppPackage = '@quasar/app';
+    const { devDependencies } = require('package.json')
+    if (!devDependencies.hasOwnProperty(quasarAppPackage)) {
+      quasarAppPackage = '@quasar/app'
     }
   }
 
@@ -77,14 +76,10 @@ async function exportQuasarConfig(bundler: AvailableBundlers): Promise<any> {
 
 export const injectDevServer: Cypress.PluginConfig = (on, config) => {
   on('dev-server:start', async (options) => {
-    let bundler: AvailableBundlers;
-
-    try {
-      await exec('npm ls @quasar/app-vite');
-      bundler = 'vite';
-    } catch (e) {
-      bundler = 'webpack';
-    }
+    const { devDependencies } = require('package.json')
+    const bundler: AvailableBundlers = devDependencies.hasOwnProperty('@quasar/app-vite') ? 
+      'vite' : 
+      'webpack';
 
     const { startDevServer } = await import(`@cypress/${bundler}-dev-server`);
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
