### PR TITLE
Change "AE" to "App Extension (AE)" in docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The packages in this repo follow the following naming convention:
 - @quasar/app-extension-testing-e2e-\*
 - @quasar/app-extension-testing-quality
 
-Quasar internally maps extensions (pruning "app-extension-") when running `quasar ext ...` commands, eg. `jest` test-runner AE id would be `@quasar/testing-unit-jest`.
+Quasar internally maps extensions (pruning "app-extension-") when running `quasar ext ...` commands, eg. `jest` test-runner App Extension (AE) id would be `@quasar/testing-unit-jest`.
 
 If you would like to help us add official harnesses, please open an issue or get in touch on Quasar Discord server #testing channel.
 Avoid opening PRs without getting in touch with us, as we may refuse to merge integrations we cannot commit to maintain.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Test Driven Design approach will help you to write better (and fewer) tests.
 
 ## Donations
 
-The Quasar team spend a considerabile amount of time studying, coding and maintaining App Extensions which save literally thousands of developers hours, days or weeks of work.
+The Quasar team spend a considerabile amount of time studying, coding and maintaining App Extensions (AE) which save literally thousands of developers hours, days or weeks of work.
 
 Does your business or personal projects depend on these App Extensions? How much time did we save you until now? Consider [donating](https://github.com/sponsors/rstoenescu) to help us maintain them and allow us to create new ones!
 

--- a/packages/e2e-cypress/README.md
+++ b/packages/e2e-cypress/README.md
@@ -26,7 +26,7 @@ Add into your `.eslintrc.js` the following code:
 
 ---
 
-This AE manages Quasar and Cypress integration for you, both for JavaScript and TypeScript.
+This App Extension (AE) manages Quasar and Cypress integration for you, both for JavaScript and TypeScript.
 
 Some custom commands are included out-of-the-box:
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -6,7 +6,7 @@
 $ quasar ext add @quasar/testing
 ```
 
-This AE is meant to centralize the management of all testing harnesses.
+This App Extension (AE) is meant to centralize the management of all testing harnesses.
 
 When added (or re-added) it will let you choose which testing harnesses you want and install them.
 It will provide a new `quasar test` command which you can use to run your tests.

--- a/packages/unit-jest/README.md
+++ b/packages/unit-jest/README.md
@@ -9,7 +9,7 @@ $ quasar ext add @quasar/testing-unit-jest@alpha
 > This package is in **alpha** phase. The public API may still change as we collect community feedback.
 > Notice that we rely on "@vue/test-utils" (VTU, currently in RC phase) and "vue-jest" (currently in alpha phase) and may not release the **stable** version of this package until those packages are released as **stable** too.
 
-This AE manages Quasar and Jest integration for you, both for JavaScript and TypeScript.
+This App Extension (AE) manages Quasar and Jest integration for you, both for JavaScript and TypeScript.
 
 What is included:
 


### PR DESCRIPTION
When coming from the web to a random page, I had no idea what AE stood for.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [x] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
