### PR TITLE
#227: Webpack code coverage support

### DIFF
--- a/packages/e2e-cypress/package.json
+++ b/packages/e2e-cypress/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.178",
+    "coverage-istanbul-loader": "^3.0.5",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/e2e-cypress/package.json
+++ b/packages/e2e-cypress/package.json
@@ -35,6 +35,7 @@
     "@cypress/vite-dev-server": "^2.2.2",
     "@cypress/vue": "^3.1.0",
     "@cypress/webpack-dev-server": "^1.8.3",
+    "coverage-istanbul-loader": "^3.0.5",
     "cross-env": "^7.0.3",
     "cypress": "^9.5.2",
     "lodash": "^4.17.21",
@@ -44,7 +45,6 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.178",
-    "coverage-istanbul-loader": "^3.0.5",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/e2e-cypress/src/index.js
+++ b/packages/e2e-cypress/src/index.js
@@ -4,6 +4,7 @@
  *
  * API: https://github.com/quasarframework/quasar/blob/master/app/lib/app-extension/IndexAPI.js
  */
+const path = require('path');
 
 module.exports = async function (api) {
   api.compatibleWith('quasar', '^2.0.0');
@@ -40,10 +41,18 @@ module.exports = async function (api) {
         );
       });
     } else {
-      // TODO: add webpack code coverage support
-      // See https://www.npmjs.com/package/istanbul-instrumenter-loader
-      // https://github.com/vuejs/vue-cli/issues/1363#issuecomment-405352542
-      // https://github.com/akoidan/vue-webpack-typescript
+      if (api.hasWebpack === true) {
+        api.extendWebpack((cfg) => {
+          cfg.module.rules.push({
+            test: /\.(js|ts|vue)$/,
+            loader: '@jsdevtools/coverage-istanbul-loader',
+            options: { esModules: true },
+            enforce: 'post',
+            include: path.join(__dirname, '..', '..', '..', '..', 'src'),
+            exclude: [/\.(e2e|spec)\.(js|ts)$/, /node_modules/],
+          });
+        });
+      }
     }
   }
 };

--- a/packages/e2e-cypress/src/index.js
+++ b/packages/e2e-cypress/src/index.js
@@ -41,18 +41,15 @@ module.exports = async function (api) {
         );
       });
     } else {
-      if (api.hasWebpack === true) {
-        api.extendWebpack((cfg) => {
-          cfg.module.rules.push({
-            test: /\.(js|ts|vue)$/,
-            loader: '@jsdevtools/coverage-istanbul-loader',
-            options: { esModules: true },
-            enforce: 'post',
-            include: path.join(__dirname, '..', '..', '..', '..', 'src'),
-            exclude: [/\.(e2e|spec)\.(js|ts)$/, /node_modules/],
-          });
+      api.extendWebpack((cfg) => {
+        cfg.module.rules.push({
+          test: /\.(js|ts|vue)$/,
+          loader: '@jsdevtools/coverage-istanbul-loader',
+          options: { esModules: true },
+          enforce: 'post',
+          exclude: [/\.(e2e|spec)\.(js|ts)$/, /node_modules/, /\.quasar/],
         });
-      }
+      });
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,6 +1586,17 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@jsdevtools/coverage-istanbul-loader@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/coverage-istanbul-loader/-/coverage-istanbul-loader-3.0.5.tgz#2a4bc65d0271df8d4435982db4af35d81754ee26"
+  integrity sha512-EUCPEkaRPvmHjWAAZkWMT7JDzpw7FKB00WTISaiXsbNOd5hCHg77XLA8sLYLFDo1zepYLo2w7GstN8YBqRXZfA==
+  dependencies:
+    convert-source-map "^1.7.0"
+    istanbul-lib-instrument "^4.0.3"
+    loader-utils "^2.0.0"
+    merge-source-map "^1.1.0"
+    schema-utils "^2.7.0"
+
 "@lerna/add@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-4.0.0.tgz#c36f57d132502a57b9e7058d1548b7a565ef183f"
@@ -2575,6 +2586,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@^7.0.5":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -3054,6 +3070,11 @@ aggregate-error@^3.0.0:
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
+
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
 ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
@@ -4588,6 +4609,13 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+coverage-istanbul-loader@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/coverage-istanbul-loader/-/coverage-istanbul-loader-3.0.5.tgz#bf942efc0f4e3ac27565203c17dca5008eae6637"
+  integrity sha512-xsw2phF0VNqUPk47V/vHXkdcTyl0tkMSmaZfLrTOhoPhPMXFelNju7utl5s7I93KXzipqDEK0YwofQSSflPz8A==
+  dependencies:
+    "@jsdevtools/coverage-istanbul-loader" "3.0.5"
 
 create-ecdh@^4.0.0:
   version "4.0.4"
@@ -8167,6 +8195,15 @@ loader-utils@^1.2.3:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+loader-utils@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
+  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 local-pkg@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.1.tgz#e7b0d7aa0b9c498a1110a5ac5b00ba66ef38cfff"
@@ -8492,6 +8529,13 @@ meow@^8.0.0:
     trim-newlines "^3.0.0"
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
+
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
+  dependencies:
+    source-map "^0.6.1"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -10532,6 +10576,15 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+schema-utils@^2.7.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
+  integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
+  dependencies:
+    "@types/json-schema" "^7.0.5"
+    ajv "^6.12.4"
+    ajv-keywords "^3.5.2"
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [ ] Documentation
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] It's been tested on Windows
- [ ] It's been tested on Linux
- [x] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- The modification introduces Webpack support for e2e-cypress package.

**Other information:**
- Instead of [istanbul-instrumenter-loader](https://www.npmjs.com/package/istanbul-instrumenter-loader) package [coverage-istanbul-loader](https://www.npmjs.com/package/coverage-istanbul-loader) was used to instrument code coverage
- The modification can be tested in [test-project-webpack](https://github.com/quasarframework/quasar-testing/tree/dev/test-project-webpack) after following the instructions:

> add @cypress/code-coverage according to this [link](https://www.npmjs.com/package/@cypress/code-coverage) (babel-plugin-istanbul isn't needed here because it's bundled with coverage-istanbul-loader.

> add `"code-coverage"` option to **quasar.extensions.json**

```
"@quasar/testing-e2e-cypress": {
    "options": [
      "scripts",
      "typescript",
      "code-coverage"
    ]
  }
```

> add nyc settings in the end of package.json
```
"nyc": {
    "temp-dir": "temp/.nyc_output",
    "include": [
      "src/**"
    ],
    "extension": [
      ".js",
      ".ts",
      ".vue"
    ],
    "report-dir": "test/cypress/coverage"
  }
```
> execute `sync:cypress` npm script in test-project-webpack project