### PR TITLE
feat(cypress): allow code coverage on builds

### DIFF
--- a/packages/e2e-cypress/src/index.js
+++ b/packages/e2e-cypress/src/index.js
@@ -36,6 +36,7 @@ module.exports = async function (api) {
         viteConf.plugins.push(
           istanbul({
             exclude: ['.quasar/*'],
+            forceBuildInstrument: true,
           }),
         );
       });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Feature

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
Sometimes it makes more sense to use `quasar build`+`quasar serve` instead of `quasar dev`, especially with Vite to avoid timeouts due to compiling on the fly. I would say it's a best practice in CI pipelines because using the production build would yield results closer to the real production environment. One could even use their actual webserver instead of `quasar serve` to also count it on the E2E tests. If you agree with any of these, I suppose we could add some information to the README file or even update the `test:e2e:ci` script template.

So, anyways, `vite-plugin-istanbul` doesn't include code coverage when building(_determined by the Vite mode, not `NODE_ENV_`) by default. So, to run E2E tests with code coverage on builds, we would need to set `forceBuildInstrument: true`.

I am classifying this as a feature, not a bug, because the scaffolded and recommended scripts use `quasar dev`, in which code coverage works nicely.