### PR TITLE
refactor(vitest): rename installQuasar in installQuasarPlugin

### DIFF
--- a/packages/unit-vitest/README.md
+++ b/packages/unit-vitest/README.md
@@ -28,7 +28,7 @@ It will also restore the original configuration after all tests completed.
 Usage:
 
 ````ts
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import ExampleComponent from '../ExampleComponent.vue';
 
@@ -148,7 +148,7 @@ const counter = computed(() => store.counter);
 ```ts
 // StoreComponent.test.ts
 
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { useCounterStore } from '../example-store';
 import { describe, expect, it } from 'vitest';
@@ -157,7 +157,7 @@ import StoreComponent from './StoreComponent.vue';
 
 // Documentation: https://pinia.vuejs.org/cookbook/testing.html#unit-testing-a-store
 
-installQuasar();
+installQuasarPlugin();
 installPinia({ stubActions: false });
 
 describe('store examples', () => {

--- a/packages/unit-vitest/README.md
+++ b/packages/unit-vitest/README.md
@@ -11,7 +11,7 @@ This App Extension (AE) manages Quasar and Vitest integration for you, both for 
 What is included:
 
 - a Vite config file with Quasar configure (`vitest.config.ts`);
-- an `installQuasarPlugin` function to help you setup and configure the test Quasar instance on a per-test-suite basis;
+- an `installQuasar` function to help you setup and configure the test Quasar instance on a per-test-suite basis;
 - some examples about how to use it with Pinia and Vue Router;
 - some example components and related example tests inside `test/vitest/__tests__`
 - some useful `package.json` scripts;
@@ -36,10 +36,10 @@ import ExampleComponent from '../ExampleComponent.vue';
  * You can provide a config object as param like such:
  *
  * ```ts
- * installQuasarPlugin({ plugins: { Dialog } });
+ * installQuasar({ plugins: { Dialog } });
  * ```
  */
-installQuasarPlugin();
+installQuasar();
 
 describe('ExampleComponent', () => {
   it('should mount correctly', async () => {

--- a/packages/unit-vitest/README.md
+++ b/packages/unit-vitest/README.md
@@ -11,7 +11,7 @@ This App Extension (AE) manages Quasar and Vitest integration for you, both for 
 What is included:
 
 - a Vite config file with Quasar configure (`vitest.config.ts`);
-- an `installQuasar` function to help you setup and configure the test Quasar instance on a per-test-suite basis;
+- an `installQuasarPlugin` function to help you setup and configure the test Quasar instance on a per-test-suite basis;
 - some examples about how to use it with Pinia and Vue Router;
 - some example components and related example tests inside `test/vitest/__tests__`
 - some useful `package.json` scripts;
@@ -36,10 +36,10 @@ import ExampleComponent from '../ExampleComponent.vue';
  * You can provide a config object as param like such:
  *
  * ```ts
- * installQuasar({ plugins: { Dialog } });
+ * installQuasarPlugin({ plugins: { Dialog } });
  * ```
  */
-installQuasar();
+installQuasarPlugin();
 
 describe('ExampleComponent', () => {
   it('should mount correctly', async () => {

--- a/packages/unit-vitest/src/helpers/install-quasar-plugin.ts
+++ b/packages/unit-vitest/src/helpers/install-quasar-plugin.ts
@@ -4,7 +4,7 @@ import { Quasar, QuasarPluginOptions } from 'quasar';
 import { qLayoutInjections } from './layout-injections';
 import { beforeAll, afterAll } from 'vitest';
 
-export function installQuasar(options?: Partial<QuasarPluginOptions>) {
+export function installQuasarPlugin(options?: Partial<QuasarPluginOptions>) {
   const globalConfigBackup = cloneDeep(config.global);
 
   beforeAll(() => {

--- a/packages/unit-vitest/src/templates/no-typescript/test/vitest/___tests__/ExampleComponent.test.js
+++ b/packages/unit-vitest/src/templates/no-typescript/test/vitest/___tests__/ExampleComponent.test.js
@@ -1,9 +1,9 @@
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import ExampleComponent from './demo/ExampleComponent.vue';
 
-installQuasar();
+installQuasarPlugin();
 
 describe('example Component', () => {
   it('should mount component with todos', () => {

--- a/packages/unit-vitest/src/templates/no-typescript/test/vitest/___tests__/NotifyComponent.test.js
+++ b/packages/unit-vitest/src/templates/no-typescript/test/vitest/___tests__/NotifyComponent.test.js
@@ -1,10 +1,10 @@
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { Notify } from 'quasar';
 import { describe, expect, it, vi } from 'vitest';
 import NotifyComponent from './demo/NotifyComponent.vue';
 
-installQuasar({ plugins: { Notify } });
+installQuasarPlugin({ plugins: { Notify } });
 
 describe('notify example', () => {
   it('should call notify on click', async () => {

--- a/packages/unit-vitest/src/templates/typescript/test/vitest/___tests__/ExampleComponent.test.ts
+++ b/packages/unit-vitest/src/templates/typescript/test/vitest/___tests__/ExampleComponent.test.ts
@@ -1,9 +1,9 @@
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import ExampleComponent from './demo/ExampleComponent.vue';
 
-installQuasar();
+installQuasarPlugin();
 
 describe('example Component', () => {
   it('should mount component with todos', () => {

--- a/packages/unit-vitest/src/templates/typescript/test/vitest/___tests__/NotifyComponent.test.ts
+++ b/packages/unit-vitest/src/templates/typescript/test/vitest/___tests__/NotifyComponent.test.ts
@@ -1,10 +1,10 @@
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { Notify } from 'quasar';
 import { describe, expect, it, vi } from 'vitest';
 import NotifyComponent from './demo/NotifyComponent.vue';
 
-installQuasar({ plugins: { Notify } });
+installQuasarPlugin({ plugins: { Notify } });
 
 describe('notify example', () => {
   it('should call notify on click', async () => {

--- a/test-project-vite/test/vitest/__tests__/ExampleComponent.test.ts
+++ b/test-project-vite/test/vitest/__tests__/ExampleComponent.test.ts
@@ -1,9 +1,9 @@
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import ExampleComponent from './demo/ExampleComponent.vue';
 
-installQuasar();
+installQuasarPlugin();
 
 describe('example Component', () => {
   it('should mount component with todos', () => {

--- a/test-project-vite/test/vitest/__tests__/LayoutComponent.test.ts
+++ b/test-project-vite/test/vitest/__tests__/LayoutComponent.test.ts
@@ -1,9 +1,9 @@
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import LayoutComponent from './demo/LayoutComponent.vue';
 
-installQuasar();
+installQuasarPlugin();
 
 describe('layout example', () => {
   it('should mount component properly', () => {

--- a/test-project-vite/test/vitest/__tests__/NotifyComponent.test.ts
+++ b/test-project-vite/test/vitest/__tests__/NotifyComponent.test.ts
@@ -1,10 +1,10 @@
-import { installQuasar } from '@quasar/quasar-app-extension-testing-unit-vitest';
+import { installQuasarPlugin } from '@quasar/quasar-app-extension-testing-unit-vitest';
 import { mount } from '@vue/test-utils';
 import { Notify } from 'quasar';
 import { describe, expect, it, vi } from 'vitest';
 import NotifyComponent from './demo/NotifyComponent.vue';
 
-installQuasar({ plugins: { Notify } });
+installQuasarPlugin({ plugins: { Notify } });
 
 describe('notify example', () => {
   it('should call notify on click', async () => {


### PR DESCRIPTION
Renamed installQuasarPlugin in installQuasar in accordance with the interface exported by the package @quasar/quasar-app-extension-testing-unit-vitest

**What kind of change does this PR introduce?**

- [x] Documentation

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Other information:**
Seems like vitest export is different from Jest and Cypress. If there is no technical reason behind, this could be misleading 😄  