### PR TITLE
fix(cypress): do not override coverage exclude

### DIFF
--- a/packages/e2e-cypress/README.md
+++ b/packages/e2e-cypress/README.md
@@ -57,20 +57,25 @@ To generate reports, run `test:e2e:ci` and/or `test:component:ci` scripts.
 Running them both sequentially within the same command (eg. `yarn test:e2e:ci && yarn test:component:ci`) will result in combined coverage report.
 You'll find the generated report into `coverage/lcov-report` folder.
 
-We provide a [preset configuration](https://github.com/quasarframework/quasar-testing/blob/dev/packages/e2e-cypress/nyc-config-preset.json) for the coverage report which:
+We provide a [preset configuration][nyc-config-preset] for the coverage report which:
 
 - enables `all` option to include some files which are ignored by default:
   - dynamically imported components, such as layout and pages imported by vue-router;
   - files not touched by any test.
 - excludes test folders (`__tests__`) and TS declaration files (\*.d.ts), which should already be excluded [by default](https://github.com/istanbuljs/schema/blob/master/default-exclude.js) but apparently aren't;
-- only includes actual code files, leaving out code-like static assets (eg. svgs).
+- only includes actual code files, leaving out code-like static assets (e.g. SVGs).
 
 Check out [nyc official documentation](https://github.com/istanbuljs/nyc) if you want to customize report generation.
 You can either add options into `.nycrc` file or generate reports on the fly running `nyc report <options>`.
 
+If you want to override the options that are defined by our [preset configuration][nyc-config-preset](_or any preset_), you should be aware of [this nyc issue](https://github.com/istanbuljs/nyc/issues/1286).
+You can either apply [this workaround](https://github.com/istanbuljs/nyc/issues/1286#issuecomment-926077635) or embed our [preset configuration][nyc-config-preset] into your `.nycrc` file directly, instead of `extends`.
+
 > Note that we do not setup [Istanbul TS configuration](https://github.com/istanbuljs/istanbuljs/tree/master/packages/nyc-config-typescript) and its dependencies as Cypress claims [it's able to manage TS code coverage out-of-the-box](https://github.com/cypress-io/code-coverage#typescript-users).
 > Some TS files may be excluded by the report in scenarios, eg. if they aren't actually imported (dead code), if they're tree-shaked away by a bundler or if they only contain types/interfaces, and as such have no actual JS representation.
 > Please open an issue if you notice some files are missing from generated reports in this scenario.
+
+[nyc-config-preset]: https://github.com/quasarframework/quasar-testing/blob/dev/packages/e2e-cypress/nyc-config-preset.json
 
 ### Upgrade from Cypress AE v4
 

--- a/packages/e2e-cypress/nyc-config-preset.json
+++ b/packages/e2e-cypress/nyc-config-preset.json
@@ -1,5 +1,5 @@
 {
   "all": true,
-  "include": ["**/*.{js,cjs,mjs,jsx,ts,tsx,vue}"],
-  "exclude": ["**/.quasar/**", "**/__tests__/**", "**/*.d.ts"]
+  "include": ["src/**/*.{js,cjs,mjs,jsx,ts,tsx,vue}"],
+  "exclude": ["**/__tests__/**", "**/*.d.ts"]
 }

--- a/packages/e2e-cypress/nyc-config-preset.json
+++ b/packages/e2e-cypress/nyc-config-preset.json
@@ -1,5 +1,5 @@
 {
   "all": true,
   "include": ["**/*.{js,cjs,mjs,jsx,ts,tsx,vue}"],
-  "exclude": ["**/__tests__/**", "**.d.ts"]
+  "exclude": ["**/.quasar/**", "**/__tests__/**", "**/*.d.ts"]
 }

--- a/packages/e2e-cypress/package.json
+++ b/packages/e2e-cypress/package.json
@@ -36,7 +36,7 @@
     "lodash": "^4.17.21",
     "nyc": "^15.1.0",
     "start-server-and-test": "^1.14.0",
-    "vite-plugin-istanbul": "^3.0.2"
+    "vite-plugin-istanbul": "^3.0.3"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.182",

--- a/packages/e2e-cypress/src/index.js
+++ b/packages/e2e-cypress/src/index.js
@@ -34,7 +34,7 @@ module.exports = async function (api) {
       api.extendViteConf((viteConf) => {
         viteConf.plugins.push(
           istanbul({
-            forceBuildInstrument: api.ctx.prod ? true : false,
+            forceBuildInstrument: api.ctx.prod,
           }),
         );
       });

--- a/packages/e2e-cypress/src/index.js
+++ b/packages/e2e-cypress/src/index.js
@@ -34,7 +34,6 @@ module.exports = async function (api) {
       api.extendViteConf((viteConf) => {
         viteConf.plugins.push(
           istanbul({
-            exclude: ['.quasar/*'],
             forceBuildInstrument: api.ctx.prod ? true : false,
           }),
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -10394,10 +10394,10 @@ vite-jsconfig-paths@^2.0.1:
     recrawl-sync "^2.0.3"
     tsconfig-paths "^3.9.0"
 
-vite-plugin-istanbul@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/vite-plugin-istanbul/-/vite-plugin-istanbul-3.0.2.tgz#abb01b337bbd3a20666d9d82d472688a99ba2796"
-  integrity sha512-eOKedaeciqJTLEAUo7mkMqXjjeAXGhHUYuiLLBUaBwj8AdO31uVOsZvKeVViRqHKyhi5YlarmGh8r7jJVlX0VQ==
+vite-plugin-istanbul@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vite-plugin-istanbul/-/vite-plugin-istanbul-3.0.3.tgz#88a0e286ccc33030b36d7809a78382cf84dd5f74"
+  integrity sha512-2nCYSsY1kgF83S007rg0GPmeL5P+bph8Z5RJ3Pv1kHHx9OMyKt/cLyGCWAYQnBk9VckzXRGEaX3FSLtcSai4Yg==
   dependencies:
     "@istanbuljs/load-nyc-config" "^1.1.0"
     istanbul-lib-instrument "^5.1.0"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
When specifying the `exclude` option in `vite-plugin-istanbul`, it uses that instead of the ones in `.nycrc`. The ones specified in `exclude` option isn't accurate either. So, this PR updates the `exclude` in `.nycrc` to cover everything, then removes the `vite-plugin-istanbul`'s `exclude` option. Now, the excludes are more accurate, and the users will be able to add more excludes in their `.nycrc` files as they wish.