### PR TITLE
fix(cypress): install v11 into userland

### DIFF
--- a/packages/e2e-cypress/package.json
+++ b/packages/e2e-cypress/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.182",
-    "cypress": "^11.0.1",
+    "cypress": "^11.2.0",
     "eslint-plugin-cypress": "^2.12.1",
     "rimraf": "^3.0.2"
   },

--- a/packages/e2e-cypress/src/install.js
+++ b/packages/e2e-cypress/src/install.js
@@ -39,7 +39,7 @@ function __mergeDeep(...sources) {
 // make sure the object exists
 let extendPackageJson = {
   devDependencies: {
-    cypress: '^10.10.0',
+    cypress: '^11.2.0',
     'eslint-plugin-cypress': '^2.12.1',
   },
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix

**Does this PR introduce a breaking change?**

- No

**The PR fulfills these requirements:**

- It's submitted to the `dev` branch and _not_ the `master` branch

**Other information:**
`@quasar/quasar-app-extension-testing-e2e-cypress@5.0.0-beta.7` uses Cypress 11 for itself, but the install script installs Cypress v10 which causes conflicts. So, this PR aims to resolve those conflicts by installing Cypress v11 into userland as well.