### PR TITLE
fix(jest): fix path to stub.css

### DIFF
--- a/packages/unit-jest/jest-preset.mjs
+++ b/packages/unit-jest/jest-preset.mjs
@@ -45,7 +45,7 @@ export const config = {
     // Quasar CJS export is SSR-only, so we need to use ESM build and transpile it with Babel
     '^quasar$': 'quasar/dist/quasar.esm.prod.js',
     '^~/(.*)$': '<rootDir>/$1',
-    '.*css$': '@quasar/quasar-app-extension-testing-unit-jest/stub.css',
+    '.*css$': '@quasar/quasar-app-extension-testing-unit-jest/src/helpers/stub.css',
     ...aliases,
   },
   transform: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar-testing/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [x] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I encountered an error

```
 Configuration error:
    
    Could not locate module src/css/table_styles.css mapped as:
    @quasar/quasar-app-extension-testing-unit-jest/stub.css.
    
    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/.*css$/": "@quasar/quasar-app-extension-testing-unit-jest/stub.css"
      },
      "resolver": undefined
    }

      1 | import { ColDef } from 'ag-grid-enterprise';
    > 2 | import 'src/css/table_styles.css';
        | ^

```

which is fixed on my site with the change of path to the stub.css. 
