### PR TITLE
update dependency vitest@^0.30.1

### DIFF
--- a/packages/unit-vitest/package.json
+++ b/packages/unit-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quasar/quasar-app-extension-testing-unit-vitest",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "A Quasar App Extension for running tests with Vitest",
   "contributors": [
@@ -46,7 +46,7 @@
     "@vitest/ui": "^0.29.1",
     "@vue/test-utils": "^2.0.0",
     "quasar": "^2.10.2",
-    "vitest": "^0.30.0",
+    "vitest": "^0.30.1",
     "vue": "^3.2.0"
   },
   "peerDependenciesMeta": {

--- a/packages/unit-vitest/package.json
+++ b/packages/unit-vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quasar/quasar-app-extension-testing-unit-vitest",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "description": "A Quasar App Extension for running tests with Vitest",
   "contributors": [
@@ -46,7 +46,7 @@
     "@vitest/ui": "^0.29.1",
     "@vue/test-utils": "^2.0.0",
     "quasar": "^2.10.2",
-    "vitest": "^0.29.1",
+    "vitest": "^0.30.1",
     "vue": "^3.2.0"
   },
   "peerDependenciesMeta": {

--- a/packages/unit-vitest/package.json
+++ b/packages/unit-vitest/package.json
@@ -46,7 +46,7 @@
     "@vitest/ui": "^0.29.1",
     "@vue/test-utils": "^2.0.0",
     "quasar": "^2.10.2",
-    "vitest": "^0.30.1",
+    "vitest": "^0.30.0",
     "vue": "^3.2.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
update dependency vitest@0.30.1

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar-testing/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:

update dependency vitest@^0.30.1

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [X] Yes    
- [ ] No

If yes, please describe the impact and migration path for existing applications:

- update vitest from 0.29.x to 0.30.1 [vitest changelog](https://github.com/vitest-dev/vitest/releases/tag/v0.30.0)

**The PR fulfills these requirements:**

- [X] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
