### PR TITLE
fix(cypress): await in vModelAdapter to ensure we don't need to call nextTick() in tests

### DIFF
--- a/packages/e2e-cypress/src/helpers/v-model-adapter.ts
+++ b/packages/e2e-cypress/src/helpers/v-model-adapter.ts
@@ -12,8 +12,9 @@ export function vModelAdapter<T>(
   // the returned object and match it with the component props this helper is applied to.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
-  watch(modelRef, (value) =>
-    Cypress.vueWrapper.setProps({ [modelName]: value }),
+  watch(
+    modelRef,
+    async (value) => await Cypress.vueWrapper.setProps({ [modelName]: value }),
   );
 
   return {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar-testing/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] New test runner
- [ ] Documentation
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**If you are adding a new test runner, have you...?** (check all)

- [ ] Created an issue first?
- [ ] Registered it in `/packages/base/runners.json`?
- [ ] Added it to `/README.md`?
- [ ] Included one test that runs `baseline.spec.vue`?
- [ ] Added and updated documentation?
- [ ] Included a recipe folder with properly building quasar project?

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on Windows
- [ ] It's been tested on Linux
- [ ] It's been tested on MacOS
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
